### PR TITLE
Update license links to LICENSE-MODEL and LICENSE-CODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@
   <a href="https://www.modelscope.cn/organization/MiniMax" target="_blank" style="margin: 2px;">
     🤖️ ModelScope
   </a> | 
-  <a href="https://github.com/MiniMax-AI/MiniMax-M2.7/blob/main/LICENSE" style="margin: 2px;">
-    📄 License: Modified-MIT
+  <a href="https://github.com/MiniMax-AI/MiniMax-M2.7/blob/main/LICENSE-MODEL" style="margin: 2px;">
+    📄 LICENSE-MODEL
+  </a> | 
+  <a href="https://github.com/MiniMax-AI/MiniMax-M2.7/blob/main/LICENSE-CODE" style="margin: 2px;">
+    📄 LICENSE-CODE
   </a>
 </div>
 


### PR DESCRIPTION
## Summary
- Replace `📄 License: Modified-MIT` with separate links to `LICENSE-MODEL` and `LICENSE-CODE`