### PR TITLE
Move NVIDIA NIM to Local Deployment Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ M2.7 features strengthened character consistency and emotional intelligence. We 
 - MiniMax Agent: https://agent.minimax.io/
 - MiniMax API: https://platform.minimax.io/
 - Token Plan: https://platform.minimax.io/subscribe/token-plan
-- MiniMax M2.7 is also available on [NVIDIA NIM Endpoint](https://build.nvidia.com)
 
 ## Local Deployment Guide
 
@@ -114,6 +113,10 @@ We recommend using [Transformers](https://github.com/huggingface/transformers) t
 ### ModelScope
 
 You also can get model weights from [modelscope](https://modelscope.cn/models/MiniMax/MiniMax-M2.7).
+
+### NVIDIA NIM
+
+MiniMax M2.7 is also available on [NVIDIA NIM Endpoint](https://build.nvidia.com).
 
 ### Inference Parameters
 


### PR DESCRIPTION
## Summary
- Move NVIDIA NIM Endpoint from "How to Use" to "Local Deployment Guide" as a subsection alongside SGLang/vLLM/Transformers/ModelScope